### PR TITLE
Detect globalThis to support edge runtime

### DIFF
--- a/source/ulid.ts
+++ b/source/ulid.ts
@@ -95,6 +95,9 @@ function detectRoot(): any {
     if (typeof global !== "undefined") {
         return global;
     }
+    if (typeof globalThis !== "undefined") {
+        return globalThis;
+    }    
     return null;
 }
 


### PR DESCRIPTION
We need to use `globalThis` rather than `global` (or `window`/`self`) to access the global scope under the Vercel Edge runtime.

Existing detection of `global` is specific to Node; `globalThis` is a newer standard to provide cross-platform support - and the required method under the Edge runtime:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#description

Fixes #20 (original issue is support for Edge runtime)