### PR TITLE
Alias node:crypto to stub when env is not node

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ const plugins = [
     }),
     resolve({ extensions: EXTENSIONS })
 ];
-if (ENV === "browser") {
+if (ENV !== "node") {
     plugins.unshift(
         alias({
             entries: [{ find: "node:crypto", replacement: "./stub.js" }]


### PR DESCRIPTION
Previously, `node:crypto` was imported when environment was anything but browser. This PR makes it so it is only loaded in Node.

should fix #13, though I don't have an environment to test it on