### PR TITLE
chore: 🔧 update postinstall script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.2.1
 _2023-10-10_
- * [#31](https://github.com/perry-mitchell/ulidx/pull/31): Use prepare instead of postinstall for git hooks
+ * [#33](https://github.com/perry-mitchell/ulidx/pull/33): Use prepare instead of postinstall for git hooks
 
 ## v2.2.0
 _2023-10-10_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # ulidx changelog
 
-## v2.2.1
-_2023-10-10_
- * [#33](https://github.com/perry-mitchell/ulidx/pull/33): Use prepare instead of postinstall for git hooks
-
 ## v2.2.0
 _2023-10-10_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ulidx changelog
 
+## v2.2.1
+_2023-10-10_
+ * [#31](https://github.com/perry-mitchell/ulidx/pull/31): Use prepare instead of postinstall for git hooks
+
 ## v2.2.0
 _2023-10-10_
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ulidx",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "ULID generator for NodeJS and the browser",
   "type": "module",
   "exports": {
@@ -38,7 +38,7 @@
     "build:types": "tsc -p tsconfig.dec.json --emitDeclarationOnly",
     "clean": "rimraf dist",
     "format": "prettier --write \"{{source,test}/**/*.{js,ts},rollup.config.js}\"",
-    "postinstall": "simple-git-hooks",
+    "prepare": "simple-git-hooks",
     "pre:commit": "lint-staged",
     "prepublishOnly": "npm run build",
     "test": "npm run build && npm run test:specs && npm run test:format",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ulidx",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "description": "ULID generator for NodeJS and the browser",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Hi. Renovate updated ulidx to 2.2.0 and our pipeline failed. I believed the issue is using the `postinstall` script to setup git hooks instead of `prepare`, which runs after `npm install`.

Because `postinstall` will run when a dependency installs their packages, while `prepare` will only ever run locally, not for dependencies of ulidx.

Might close #32 