### PR TITLE
feat: convert ULID to UUID and vice versa

### DIFF
--- a/source/constants.ts
+++ b/source/constants.ts
@@ -1,2 +1,6 @@
 export const MAX_ULID = "7ZZZZZZZZZZZZZZZZZZZZZZZZZ";
 export const MIN_ULID = "00000000000000000000000000";
+
+export const ULID_REGEX = /^[0-7][0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{25}$/;
+export const UUID_REGEX = /^[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
+export const B32_CHARACTERS = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";

--- a/source/crockford.ts
+++ b/source/crockford.ts
@@ -1,0 +1,58 @@
+// Code from https://github.com/devbanana/crockford-base32/blob/develop/src/index.ts
+import { B32_CHARACTERS } from "./constants.js";
+
+export function crockfordEncode(input: Uint8Array): string {
+    const output: number[] = [];
+    let bitsRead = 0;
+    let buffer = 0;
+
+    const reversedInput = new Uint8Array(input.slice().reverse());
+
+    for (const byte of reversedInput) {
+        buffer |= byte << bitsRead;
+        bitsRead += 8;
+
+        while (bitsRead >= 5) {
+            output.unshift(buffer & 0x1f);
+            buffer >>>= 5;
+            bitsRead -= 5;
+        }
+    }
+
+    if (bitsRead > 0) {
+        output.unshift(buffer & 0x1f);
+    }
+
+    return output.map(byte => B32_CHARACTERS.charAt(byte)).join("");
+}
+
+export function crockfordDecode(input: string): Uint8Array {
+    const sanitizedInput = input.toUpperCase().split("").reverse().join("");
+
+    const output: number[] = [];
+    let bitsRead = 0;
+    let buffer = 0;
+
+    for (const character of sanitizedInput) {
+        const byte = B32_CHARACTERS.indexOf(character);
+
+        if (byte === -1) {
+            throw new Error(`Invalid base 32 character found in string: ${character}`);
+        }
+
+        buffer |= byte << bitsRead;
+        bitsRead += 5;
+
+        while (bitsRead >= 8) {
+            output.unshift(buffer & 0xff);
+            buffer >>>= 8;
+            bitsRead -= 8;
+        }
+    }
+
+    if (bitsRead >= 5 || buffer > 0) {
+        output.unshift(buffer & 0xff);
+    }
+
+    return new Uint8Array(output);
+}

--- a/source/index.ts
+++ b/source/index.ts
@@ -5,7 +5,9 @@ export {
     detectPRNG,
     isValid,
     monotonicFactory,
-    ulid
+    ulid,
+    ulidToUUID,
+    uuidToULID
 } from "./ulid.js";
 export * from "./constants.js";
 export * from "./types.js";

--- a/source/types.ts
+++ b/source/types.ts
@@ -3,3 +3,5 @@ export type PRNG = () => number;
 export type ULID = string;
 
 export type ULIDFactory = (seedTime?: number) => ULID;
+
+export type UUID = string;

--- a/test/browser-cjs/index.spec.cjs
+++ b/test/browser-cjs/index.spec.cjs
@@ -3,13 +3,17 @@ const sinon = require("sinon");
 const {
     MAX_ULID,
     MIN_ULID,
+    ULID_REGEX,
+    UUID_REGEX,
     decodeTime,
     detectPRNG,
     encodeTime,
     fixULIDBase32,
     isValid,
     monotonicFactory,
-    ulid
+    ulid,
+    ulidToUUID,
+    uuidToULID
 } = require("../../dist/browser/index.cjs");
 
 describe("ulid", function() {
@@ -223,6 +227,30 @@ describe("ulid", function() {
 
         it("should export MAX_ULID", function () {
             expect(MAX_ULID).to.equal("7ZZZZZZZZZZZZZZZZZZZZZZZZZ");
+        });
+    });
+
+    describe("ulid to uuid", function() {
+        it("should return a valid uuid", function() {
+            expect(ulidToUUID(ulid())).to.match(UUID_REGEX);
+        });
+
+        it("should throw an error if an invalid ulid is provided", function() {
+            expect(() => {
+                ulidToUUID("whatever");
+            }).to.throw(/Invalid ULID/);
+        });
+    });
+
+    describe("uuid to ulid", function() {
+        it("should return a valid ulid", function() {
+            expect(uuidToULID("8299b5fe-3824-45b6-9bc9-b13ec3b3656c")).to.match(ULID_REGEX);
+        });
+
+        it("should throw an error if an invalid uuid is provided", function() {
+            expect(() => {
+                uuidToULID("whatever");
+            }).to.throw(/Invalid UUID/);
         });
     });
 });

--- a/test/node-cjs/index.spec.cjs
+++ b/test/node-cjs/index.spec.cjs
@@ -1,15 +1,20 @@
 const { expect } = require("chai");
 const sinon = require("sinon");
+const { randomUUID } = require("node:crypto");
 const {
     MAX_ULID,
     MIN_ULID,
+    ULID_REGEX,
+    UUID_REGEX,
     decodeTime,
     detectPRNG,
     encodeTime,
     fixULIDBase32,
     isValid,
     monotonicFactory,
-    ulid
+    ulid,
+    ulidToUUID,
+    uuidToULID
 } = require("../../dist/node/index.cjs");
 
 describe("ulid", function() {
@@ -223,6 +228,30 @@ describe("ulid", function() {
 
         it("should export MAX_ULID", function () {
             expect(MAX_ULID).to.equal("7ZZZZZZZZZZZZZZZZZZZZZZZZZ");
+        });
+    });
+
+    describe("ulid to uuid", function() {
+        it("should return a valid uuid", function() {
+            expect(ulidToUUID(ulid())).to.match(UUID_REGEX);
+        });
+
+        it("should throw an error if an invalid ulid is provided", function() {
+            expect(() => {
+                ulidToUUID("whatever");
+            }).to.throw(/Invalid ULID/);
+        });
+    });
+
+    describe("uuid to ulid", function() {
+        it("should return a valid ulid", function() {
+            expect(uuidToULID(randomUUID())).to.match(ULID_REGEX);
+        });
+
+        it("should throw an error if an invalid uuid is provided", function() {
+            expect(() => {
+                uuidToULID("whatever");
+            }).to.throw(/Invalid UUID/);
         });
     });
 });

--- a/test/node-esm/index.spec.js
+++ b/test/node-esm/index.spec.js
@@ -1,15 +1,20 @@
 import { expect } from "chai";
 import sinon from "sinon";
+import { randomUUID } from "node:crypto";
 import {
     MAX_ULID,
     MIN_ULID,
+    ULID_REGEX,
+    UUID_REGEX,
     decodeTime,
     detectPRNG,
     encodeTime,
     fixULIDBase32,
     isValid,
     monotonicFactory,
-    ulid
+    ulid,
+    ulidToUUID,
+    uuidToULID
 } from "../../dist/node/index.js";
 
 describe("ulid", function () {
@@ -223,6 +228,30 @@ describe("ulid", function () {
 
         it("should export MAX_ULID", function () {
             expect(MAX_ULID).to.equal("7ZZZZZZZZZZZZZZZZZZZZZZZZZ");
+        });
+    });
+
+    describe("ulid to uuid", function () {
+        it("should return a valid uuid", function () {
+            expect(ulidToUUID(ulid())).to.match(UUID_REGEX);
+        });
+
+        it("should throw an error if an invalid ulid is provided", function () {
+            expect(() => {
+                ulidToUUID("whatever");
+            }).to.throw(/Invalid ULID/);
+        });
+    });
+
+    describe("uuid to ulid", function () {
+        it("should return a valid ulid", function () {
+            expect(uuidToULID(randomUUID())).to.match(ULID_REGEX);
+        });
+
+        it("should throw an error if an invalid uuid is provided", function () {
+            expect(() => {
+                uuidToULID("whatever");
+            }).to.throw(/Invalid UUID/);
         });
     });
 });


### PR DESCRIPTION
Added functions to convert a ULID to a UUID, and vice versa.

For example:
```javascript
const ULID = ulid(); // 01HHAGK730AEX50PA89H1ZG25T
const UUID = ULIDtoUUID(ULID); // 018c5509-9c60-53ba-5059-484c43f808ba
const toULID = UUIDtoULID(UUID); // 01HHAGK730AEX50PA89H1ZG25T
```

Solving the issue: https://github.com/perry-mitchell/ulidx/issues/28