### PR TITLE
Fix benchmarks

### DIFF
--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,5 +1,5 @@
 import Benchmark from "benchmark";
-import { ulid } from "../dist/esm/index.js";
+import { ulid } from "../dist/node/index.js";
 
 const suite = new Benchmark.Suite();
 


### PR DESCRIPTION
`npm run bench` fails because `test/benchmark.js` tries to include from `dist/esm`, which isn't there in my builds.

This seems to be the minimal fix to get benchmarks working again.