### PR TITLE
The PRNG now returns an arraylike for performance reasons

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -1,4 +1,4 @@
-export type PRNG = () => number;
+export type PRNG = (len: number) => Uint8Array | Buffer;
 
 export type ULID = string;
 

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,5 +1,5 @@
 import Benchmark from "benchmark";
-import { ulid } from "../dist/esm/index.js";
+import { ulid } from "../dist/node/index.js";
 
 const suite = new Benchmark.Suite();
 

--- a/test/browser-cjs/index.spec.cjs
+++ b/test/browser-cjs/index.spec.cjs
@@ -16,36 +16,36 @@ const {
     uuidToULID
 } = require("../../dist/browser/index.cjs");
 
-describe("ulid", function() {
-    describe("decodeTime", function() {
-        it("should return correct timestamp", function() {
+describe("ulid", function () {
+    describe("decodeTime", function () {
+        it("should return correct timestamp", function () {
             const timestamp = Date.now();
             const id = ulid(timestamp);
             expect(decodeTime(id)).to.equal(timestamp);
         });
 
-        it("should return correct timestamp for README example", function() {
+        it("should return correct timestamp for README example", function () {
             const id = "01ARYZ6S41TSV4RRFFQ69G5FAV";
             expect(decodeTime(id)).to.equal(1469918176385);
         });
 
-        it("should support decoding lower-case ULIDs", function() {
+        it("should support decoding lower-case ULIDs", function () {
             const id = "01aryz6s41tsv4rrffq69g5fav";
             expect(decodeTime(id)).to.equal(1469918176385);
         });
 
-        it("should accept the maximum allowed timestamp", function() {
+        it("should accept the maximum allowed timestamp", function () {
             expect(decodeTime("7ZZZZZZZZZZZZZZZZZZZZZZZZZ")).to.equal(281474976710655);
         });
 
-        describe("should reject", function() {
-            it("malformed strings of incorrect length", function() {
+        describe("should reject", function () {
+            it("malformed strings of incorrect length", function () {
                 expect(() => {
                     decodeTime("FFFF");
                 }).to.throw(/Malformed ULID/);
             });
 
-            it("strings with timestamps that are too high", function() {
+            it("strings with timestamps that are too high", function () {
                 expect(() => {
                     decodeTime("80000000000000000000000000");
                 }).to.throw(/Malformed ULID: timestamp too large/);
@@ -53,66 +53,66 @@ describe("ulid", function() {
         });
     });
 
-    describe("detectPRNG", function() {
-        it("should return a function", function() {
+    describe("detectPRNG", function () {
+        it("should return a function", function () {
             expect(detectPRNG()).to.be.a("function");
         });
 
-        describe("returned function", function() {
-            beforeEach(function() {
+        describe("returned function", function () {
+            beforeEach(function () {
                 this.prng = detectPRNG();
             });
 
-            it("should produce a number", function() {
-                expect(this.prng()).to.be.a("number");
-                expect(this.prng()).to.satisfy(num => !isNaN(num));
+            it("should produce an array with numbers", function () {
+                expect(this.prng(1)[0]).to.be.a("number");
+                expect(this.prng(1)[0]).to.satisfy(num => !isNaN(num));
             });
 
-            it("should be between 0 and 1", function() {
-                expect(this.prng()).to.satisfy(num => num >= 0 && num <= 1);
+            it("should be between 0 and 255", function () {
+                expect(this.prng(1)[0]).to.satisfy(num => num >= 0 && num <= 255);
             });
         });
     });
 
-    describe("encodeTime", function() {
-        it("should return expected encoded result", function() {
+    describe("encodeTime", function () {
+        it("should return expected encoded result", function () {
             expect(encodeTime(1469918176385, 10)).to.equal("01ARYZ6S41");
         });
 
-        it("should change length properly", function() {
+        it("should change length properly", function () {
             expect(encodeTime(1470264322240, 12)).to.equal("0001AS99AA60");
         });
 
-        it("should truncate time if not enough length", function() {
+        it("should truncate time if not enough length", function () {
             expect(encodeTime(1470118279201, 8)).to.equal("AS4Y1E11");
         });
 
-        describe("should throw an error", function() {
-            it("if time greater than (2 ^ 48) - 1", function() {
+        describe("should throw an error", function () {
+            it("if time greater than (2 ^ 48) - 1", function () {
                 expect(() => {
                     encodeTime(Math.pow(2, 48), 8);
                 }).to.throw(/Cannot encode a time larger than/);
             });
 
-            it("if time is not a number", function() {
+            it("if time is not a number", function () {
                 expect(() => {
                     encodeTime("test");
                 }).to.throw(/Time must be a number/);
             });
 
-            it("if time is infinity", function() {
+            it("if time is infinity", function () {
                 expect(() => {
                     encodeTime(Infinity);
                 }).to.throw(/Cannot encode a time larger than/);
             });
 
-            it("if time is negative", function() {
+            it("if time is negative", function () {
                 expect(() => {
                     encodeTime(-1);
                 }).to.throw(/Time must be positive/);
             });
 
-            it("if time is a float", function() {
+            it("if time is a float", function () {
                 expect(() => {
                     encodeTime(100.1);
                 }).to.throw(/Time must be an integer/);
@@ -120,66 +120,72 @@ describe("ulid", function() {
         });
     });
 
-    describe("fixULIDBase32", function() {
-        it("should return the same ULID if no typos or hyphens are present", function() {
+    describe("fixULIDBase32", function () {
+        it("should return the same ULID if no typos or hyphens are present", function () {
             expect(fixULIDBase32("01ARYZ6S41TSV4RRFFQ69G5FAV")).to.equal(
                 "01ARYZ6S41TSV4RRFFQ69G5FAV"
             );
         });
 
-        it("should return the correct ULID with typos fixed", function() {
+        it("should return the correct ULID with typos fixed", function () {
             expect(fixULIDBase32("oLARYZ6S41TSV4RRFFQ69G5FAV")).to.equal(
                 "01ARYZ6S41TSV4RRFFQ69G5FAV"
             );
         });
 
-        it("should return the correct ULID with hyphens removed", function() {
+        it("should return the correct ULID with hyphens removed", function () {
             expect(fixULIDBase32("01ARYZ6-S41TSV4RRF-FQ69G5FAV")).to.equal(
                 "01ARYZ6S41TSV4RRFFQ69G5FAV"
             );
         });
 
-        it("should return the correct ULID with typos fixed and hyphens removed", function() {
+        it("should return the correct ULID with typos fixed and hyphens removed", function () {
             expect(fixULIDBase32("oLARYZ6-S41TSV4RRF-FQ69G5FAV")).to.equal(
                 "01ARYZ6S41TSV4RRFFQ69G5FAV"
             );
         });
     });
 
-    describe("isValid", function() {
-        it("should return true for valid ULIDs (uppercase)", function() {
+    describe("isValid", function () {
+        it("should return true for valid ULIDs (uppercase)", function () {
             expect(isValid("01ARYZ6S41TSV4RRFFQ69G5FAV")).to.be.true;
         });
 
-        it("should return true for valid ULIDs (lowercase)", function() {
+        it("should return true for valid ULIDs (lowercase)", function () {
             expect(isValid("01aryz6s41tsv4rrffq69g5fav")).to.be.true;
         });
 
-        it("should return false for invalid ULIDs (wrong length)", function() {
+        it("should return false for invalid ULIDs (wrong length)", function () {
             expect(isValid("01ARYZ6S41TSV4RRFFQ69G5FA")).to.be.false;
         });
 
-        it("should return false for invalid ULIDs (wrong characters)", function() {
+        it("should return false for invalid ULIDs (wrong characters)", function () {
             expect(isValid("01ARYZ6S41TSV4RRFFQ69G5FA!")).to.be.false;
         });
 
-        it("should return false for invalid ULIDs (wrong type)", function() {
+        it("should return false for invalid ULIDs (wrong type)", function () {
             expect(isValid(123)).to.be.false;
         });
     });
 
-    describe("monotonicFactory", function() {
-        it("outputs a function", function() {
+    describe("monotonicFactory", function () {
+        it("outputs a function", function () {
             expect(monotonicFactory()).to.be.a("function");
         });
 
-        describe("returned function", function() {
-            before(function() {
-                this.prng = sinon.stub().returns(0.96);
+        describe("returned function", function () {
+            before(function () {
+                this.prng = sinon
+                    .stub()
+                    .returns(
+                        Uint8Array.from([
+                            30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30
+                        ])
+                    );
             });
 
-            describe("without seedTime", function() {
-                before(function() {
+            describe("without seedTime", function () {
+                before(function () {
                     this.clock = sinon.useFakeTimers({
                         now: 1469918176385,
                         toFake: ["Date"]
@@ -187,35 +193,35 @@ describe("ulid", function() {
                     this.ulid = monotonicFactory(this.prng);
                 });
 
-                after(function() {
+                after(function () {
                     this.clock.restore();
                 });
 
-                it("first call", function() {
+                it("first call", function () {
                     expect(this.ulid()).to.equal("01ARYZ6S41YYYYYYYYYYYYYYYY");
                 });
 
-                it("second call", function() {
+                it("second call", function () {
                     expect(this.ulid()).to.equal("01ARYZ6S41YYYYYYYYYYYYYYYZ");
                 });
 
-                it("third call", function() {
+                it("third call", function () {
                     expect(this.ulid()).to.equal("01ARYZ6S41YYYYYYYYYYYYYYZ0");
                 });
 
-                it("fourth call", function() {
+                it("fourth call", function () {
                     expect(this.ulid()).to.equal("01ARYZ6S41YYYYYYYYYYYYYYZ1");
                 });
             });
         });
     });
 
-    describe("ulid", function() {
-        it("should return correct length", function() {
+    describe("ulid", function () {
+        it("should return correct length", function () {
             expect(ulid()).to.have.a.lengthOf(26);
         });
 
-        it("should return expected encoded time component result", function() {
+        it("should return expected encoded time component result", function () {
             expect(ulid(1469918176385).substring(0, 10)).to.equal("01ARYZ6S41");
         });
     });
@@ -230,24 +236,24 @@ describe("ulid", function() {
         });
     });
 
-    describe("ulid to uuid", function() {
-        it("should return a valid uuid", function() {
+    describe("ulid to uuid", function () {
+        it("should return a valid uuid", function () {
             expect(ulidToUUID(ulid())).to.match(UUID_REGEX);
         });
 
-        it("should throw an error if an invalid ulid is provided", function() {
+        it("should throw an error if an invalid ulid is provided", function () {
             expect(() => {
                 ulidToUUID("whatever");
             }).to.throw(/Invalid ULID/);
         });
     });
 
-    describe("uuid to ulid", function() {
-        it("should return a valid ulid", function() {
+    describe("uuid to ulid", function () {
+        it("should return a valid ulid", function () {
             expect(uuidToULID("8299b5fe-3824-45b6-9bc9-b13ec3b3656c")).to.match(ULID_REGEX);
         });
 
-        it("should throw an error if an invalid uuid is provided", function() {
+        it("should throw an error if an invalid uuid is provided", function () {
             expect(() => {
                 uuidToULID("whatever");
             }).to.throw(/Invalid UUID/);

--- a/test/node-cjs/index.spec.cjs
+++ b/test/node-cjs/index.spec.cjs
@@ -17,36 +17,36 @@ const {
     uuidToULID
 } = require("../../dist/node/index.cjs");
 
-describe("ulid", function() {
-    describe("decodeTime", function() {
-        it("should return correct timestamp", function() {
+describe("ulid", function () {
+    describe("decodeTime", function () {
+        it("should return correct timestamp", function () {
             const timestamp = Date.now();
             const id = ulid(timestamp);
             expect(decodeTime(id)).to.equal(timestamp);
         });
 
-        it("should return correct timestamp for README example", function() {
+        it("should return correct timestamp for README example", function () {
             const id = "01ARYZ6S41TSV4RRFFQ69G5FAV";
             expect(decodeTime(id)).to.equal(1469918176385);
         });
 
-        it("should support decoding lower-case ULIDs", function() {
+        it("should support decoding lower-case ULIDs", function () {
             const id = "01aryz6s41tsv4rrffq69g5fav";
             expect(decodeTime(id)).to.equal(1469918176385);
         });
 
-        it("should accept the maximum allowed timestamp", function() {
+        it("should accept the maximum allowed timestamp", function () {
             expect(decodeTime("7ZZZZZZZZZZZZZZZZZZZZZZZZZ")).to.equal(281474976710655);
         });
 
-        describe("should reject", function() {
-            it("malformed strings of incorrect length", function() {
+        describe("should reject", function () {
+            it("malformed strings of incorrect length", function () {
                 expect(() => {
                     decodeTime("FFFF");
                 }).to.throw(/Malformed ULID/);
             });
 
-            it("strings with timestamps that are too high", function() {
+            it("strings with timestamps that are too high", function () {
                 expect(() => {
                     decodeTime("80000000000000000000000000");
                 }).to.throw(/Malformed ULID: timestamp too large/);
@@ -54,66 +54,66 @@ describe("ulid", function() {
         });
     });
 
-    describe("detectPRNG", function() {
-        it("should return a function", function() {
+    describe("detectPRNG", function () {
+        it("should return a function", function () {
             expect(detectPRNG()).to.be.a("function");
         });
 
-        describe("returned function", function() {
-            beforeEach(function() {
+        describe("returned function", function () {
+            beforeEach(function () {
                 this.prng = detectPRNG();
             });
 
-            it("should produce a number", function() {
-                expect(this.prng()).to.be.a("number");
-                expect(this.prng()).to.satisfy(num => !isNaN(num));
+            it("should produce an array with numbers", function () {
+                expect(this.prng(1)[0]).to.be.a("number");
+                expect(this.prng(1)[0]).to.satisfy(num => !isNaN(num));
             });
 
-            it("should be between 0 and 1", function() {
-                expect(this.prng()).to.satisfy(num => num >= 0 && num <= 1);
+            it("should be between 0 and 255", function () {
+                expect(this.prng(1)[0]).to.satisfy(num => num >= 0 && num <= 255);
             });
         });
     });
 
-    describe("encodeTime", function() {
-        it("should return expected encoded result", function() {
+    describe("encodeTime", function () {
+        it("should return expected encoded result", function () {
             expect(encodeTime(1469918176385, 10)).to.equal("01ARYZ6S41");
         });
 
-        it("should change length properly", function() {
+        it("should change length properly", function () {
             expect(encodeTime(1470264322240, 12)).to.equal("0001AS99AA60");
         });
 
-        it("should truncate time if not enough length", function() {
+        it("should truncate time if not enough length", function () {
             expect(encodeTime(1470118279201, 8)).to.equal("AS4Y1E11");
         });
 
-        describe("should throw an error", function() {
-            it("if time greater than (2 ^ 48) - 1", function() {
+        describe("should throw an error", function () {
+            it("if time greater than (2 ^ 48) - 1", function () {
                 expect(() => {
                     encodeTime(Math.pow(2, 48), 8);
                 }).to.throw(/Cannot encode a time larger than/);
             });
 
-            it("if time is not a number", function() {
+            it("if time is not a number", function () {
                 expect(() => {
                     encodeTime("test");
                 }).to.throw(/Time must be a number/);
             });
 
-            it("if time is infinity", function() {
+            it("if time is infinity", function () {
                 expect(() => {
                     encodeTime(Infinity);
                 }).to.throw(/Cannot encode a time larger than/);
             });
 
-            it("if time is negative", function() {
+            it("if time is negative", function () {
                 expect(() => {
                     encodeTime(-1);
                 }).to.throw(/Time must be positive/);
             });
 
-            it("if time is a float", function() {
+            it("if time is a float", function () {
                 expect(() => {
                     encodeTime(100.1);
                 }).to.throw(/Time must be an integer/);
@@ -121,66 +121,72 @@ describe("ulid", function() {
         });
     });
 
-    describe("fixULIDBase32", function() {
-        it("should return the same ULID if no typos or hyphens are present", function() {
+    describe("fixULIDBase32", function () {
+        it("should return the same ULID if no typos or hyphens are present", function () {
             expect(fixULIDBase32("01ARYZ6S41TSV4RRFFQ69G5FAV")).to.equal(
                 "01ARYZ6S41TSV4RRFFQ69G5FAV"
             );
         });
 
-        it("should return the correct ULID with typos fixed", function() {
+        it("should return the correct ULID with typos fixed", function () {
             expect(fixULIDBase32("oLARYZ6S41TSV4RRFFQ69G5FAV")).to.equal(
                 "01ARYZ6S41TSV4RRFFQ69G5FAV"
             );
         });
 
-        it("should return the correct ULID with hyphens removed", function() {
+        it("should return the correct ULID with hyphens removed", function () {
             expect(fixULIDBase32("01ARYZ6-S41TSV4RRF-FQ69G5FAV")).to.equal(
                 "01ARYZ6S41TSV4RRFFQ69G5FAV"
             );
         });
 
-        it("should return the correct ULID with typos fixed and hyphens removed", function() {
+        it("should return the correct ULID with typos fixed and hyphens removed", function () {
             expect(fixULIDBase32("oLARYZ6-S41TSV4RRF-FQ69G5FAV")).to.equal(
                 "01ARYZ6S41TSV4RRFFQ69G5FAV"
             );
         });
     });
 
-    describe("isValid", function() {
-        it("should return true for valid ULIDs (uppercase)", function() {
+    describe("isValid", function () {
+        it("should return true for valid ULIDs (uppercase)", function () {
             expect(isValid("01ARYZ6S41TSV4RRFFQ69G5FAV")).to.be.true;
         });
 
-        it("should return true for valid ULIDs (lowercase)", function() {
+        it("should return true for valid ULIDs (lowercase)", function () {
             expect(isValid("01aryz6s41tsv4rrffq69g5fav")).to.be.true;
         });
 
-        it("should return false for invalid ULIDs (wrong length)", function() {
+        it("should return false for invalid ULIDs (wrong length)", function () {
             expect(isValid("01ARYZ6S41TSV4RRFFQ69G5FA")).to.be.false;
         });
 
-        it("should return false for invalid ULIDs (wrong characters)", function() {
+        it("should return false for invalid ULIDs (wrong characters)", function () {
             expect(isValid("01ARYZ6S41TSV4RRFFQ69G5FA!")).to.be.false;
         });
 
-        it("should return false for invalid ULIDs (wrong type)", function() {
+        it("should return false for invalid ULIDs (wrong type)", function () {
             expect(isValid(123)).to.be.false;
         });
     });
 
-    describe("monotonicFactory", function() {
-        it("outputs a function", function() {
+    describe("monotonicFactory", function () {
+        it("outputs a function", function () {
             expect(monotonicFactory()).to.be.a("function");
         });
 
-        describe("returned function", function() {
-            before(function() {
-                this.prng = sinon.stub().returns(0.96);
+        describe("returned function", function () {
+            before(function () {
+                this.prng = sinon
+                    .stub()
+                    .returns(
+                        Uint8Array.from([
+                            30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30
+                        ])
+                    );
             });
 
-            describe("without seedTime", function() {
-                before(function() {
+            describe("without seedTime", function () {
+                before(function () {
                     this.clock = sinon.useFakeTimers({
                         now: 1469918176385,
                         toFake: ["Date"]
@@ -188,35 +194,35 @@ describe("ulid", function() {
                     this.ulid = monotonicFactory(this.prng);
                 });
 
-                after(function() {
+                after(function () {
                     this.clock.restore();
                 });
 
-                it("first call", function() {
+                it("first call", function () {
                     expect(this.ulid()).to.equal("01ARYZ6S41YYYYYYYYYYYYYYYY");
                 });
 
-                it("second call", function() {
+                it("second call", function () {
                     expect(this.ulid()).to.equal("01ARYZ6S41YYYYYYYYYYYYYYYZ");
                 });
 
-                it("third call", function() {
+                it("third call", function () {
                     expect(this.ulid()).to.equal("01ARYZ6S41YYYYYYYYYYYYYYZ0");
                 });
 
-                it("fourth call", function() {
+                it("fourth call", function () {
                     expect(this.ulid()).to.equal("01ARYZ6S41YYYYYYYYYYYYYYZ1");
                 });
             });
         });
     });
 
-    describe("ulid", function() {
-        it("should return correct length", function() {
+    describe("ulid", function () {
+        it("should return correct length", function () {
             expect(ulid()).to.have.a.lengthOf(26);
         });
 
-        it("should return expected encoded time component result", function() {
+        it("should return expected encoded time component result", function () {
             expect(ulid(1469918176385).substring(0, 10)).to.equal("01ARYZ6S41");
         });
     });
@@ -231,24 +237,24 @@ describe("ulid", function() {
         });
     });
 
-    describe("ulid to uuid", function() {
-        it("should return a valid uuid", function() {
+    describe("ulid to uuid", function () {
+        it("should return a valid uuid", function () {
             expect(ulidToUUID(ulid())).to.match(UUID_REGEX);
         });
 
-        it("should throw an error if an invalid ulid is provided", function() {
+        it("should throw an error if an invalid ulid is provided", function () {
             expect(() => {
                 ulidToUUID("whatever");
             }).to.throw(/Invalid ULID/);
         });
     });
 
-    describe("uuid to ulid", function() {
-        it("should return a valid ulid", function() {
+    describe("uuid to ulid", function () {
+        it("should return a valid ulid", function () {
             expect(uuidToULID(randomUUID())).to.match(ULID_REGEX);
         });
 
-        it("should throw an error if an invalid uuid is provided", function() {
+        it("should throw an error if an invalid uuid is provided", function () {
             expect(() => {
                 uuidToULID("whatever");
             }).to.throw(/Invalid UUID/);

--- a/test/node-esm/index.spec.js
+++ b/test/node-esm/index.spec.js
@@ -64,13 +64,13 @@ describe("ulid", function () {
                 this.prng = detectPRNG();
             });
 
-            it("should produce a number", function () {
-                expect(this.prng()).to.be.a("number");
-                expect(this.prng()).to.satisfy(num => !isNaN(num));
+            it("should produce an array with numbers", function () {
+                expect(this.prng(1)[0]).to.be.a("number");
+                expect(this.prng(1)[0]).to.satisfy(num => !isNaN(num));
             });
 
-            it("should be between 0 and 1", function () {
-                expect(this.prng()).to.satisfy(num => num >= 0 && num <= 1);
+            it("should be between 0 and 255", function () {
+                expect(this.prng(1)[0]).to.satisfy(num => num >= 0 && num <= 255);
             });
         });
     });
@@ -176,7 +176,13 @@ describe("ulid", function () {
 
         describe("returned function", function () {
             before(function () {
-                this.prng = sinon.stub().returns(0.96);
+                this.prng = sinon
+                    .stub()
+                    .returns(
+                        Uint8Array.from([
+                            30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30
+                        ])
+                    );
             });
 
             describe("without seedTime", function () {


### PR DESCRIPTION
Cleaner (re)implementation of the changes proposed and benchmarked in #45, including adapting the tests.

(Necessarily includes #46)